### PR TITLE
encodeKV() does not return encoding errors

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -317,5 +317,9 @@ func encodeKV(b []byte, name string, v interface{}) (int, error) {
 		return 0, fmt.Errorf("encode k/v (%s): type %T is not handled", name, v)
 	}
 
+	if err != nil {
+		return 0, err
+	}
+
 	return n + m, nil
 }


### PR DESCRIPTION
This function ignores encoding errors.
This patch fixes this miss.

This would have saved me a lot of time when troubleshooting https://github.com/criteo/haproxy-spoe-go/issues/1 !