### PR TITLE
Add utils function to decode headers

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,37 @@
+package spoe
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func DecodeHeaders(headers []byte) (http.Header, error) {
+	res := make(http.Header)
+	pos := 0
+	for pos < len(headers) {
+		key, n, err := decodeString(headers[pos:])
+		if err != nil {
+			return nil, errors.Wrap(err, "error decoding headers")
+		}
+		pos += n
+
+		value, n, err := decodeString(headers[pos:])
+		if err != nil {
+			return nil, errors.Wrap(err, "error decoding headers")
+		}
+		pos += n
+
+		if key == "" && value == "" {
+			if pos != len(headers) {
+				return nil, fmt.Errorf("error decoding headers: received empty values before end of buffer")
+			}
+			break
+		}
+
+		res.Add(key, value)
+	}
+
+	return res, nil
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,45 @@
+package spoe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeHeaders(t *testing.T) {
+	headers := make([]byte, 1024)
+	pos := 0
+
+	// add a first header
+	n, err := encodeString(headers[pos:], "X-Foo")
+	require.NoError(t, err)
+	pos += n
+	n, err = encodeString(headers[pos:], "bar")
+	require.NoError(t, err)
+	pos += n
+
+	// a second one, non canonical form
+	n, err = encodeString(headers[pos:], "x-foo2")
+	require.NoError(t, err)
+	pos += n
+	n, err = encodeString(headers[pos:], "bar2")
+	require.NoError(t, err)
+	pos += n
+
+	// termination sequence
+	n, err = encodeString(headers[pos:], "")
+	require.NoError(t, err)
+	pos += n
+	n, err = encodeString(headers[pos:], "")
+	require.NoError(t, err)
+	pos += n
+
+	headers = headers[:pos]
+
+	res, err := DecodeHeaders(headers)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(res))
+	require.Equal(t, "bar", res.Get("X-Foo"))
+	require.Equal(t, "bar2", res.Get("X-Foo2"))
+}


### PR DESCRIPTION
Haproxy encodes headers in a bin format described in:
http://man.hubwiz.com/docset/HAProxy.docset/Contents/Resources/Documents/1.8.14/configuration.html#7.3.5-req.hdrs_bin

This adds function to decode them in SPOE agents.

Fixes: #5