### PR TITLE
Expose argument count; use to limit map capacity

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -34,12 +34,16 @@ func (i *ArgIterator) Next() bool {
 }
 
 func (i *ArgIterator) Map() map[string]interface{} {
-	res := map[string]interface{}{}
+	res := make(map[string]interface{}, i.count)
 	for i.Next() {
 		res[i.Arg.Name] = i.Arg.Value
 	}
 
 	return res
+}
+
+func (i *ArgIterator) Count() int {
+	return i.count
 }
 
 type Message struct {

--- a/notify_test.go
+++ b/notify_test.go
@@ -60,6 +60,7 @@ func TestNotify(t *testing.T) {
 			ok := msgs.Next()
 			require.True(t, ok)
 			require.Equal(t, "message-1", msgs.Message.Name)
+			require.Equal(t, 2, msgs.Message.Args.Count())
 			args := msgs.Message.Args.Map()
 			require.Equal(t, map[string]interface{}{
 				"key-1": "value1",
@@ -69,6 +70,7 @@ func TestNotify(t *testing.T) {
 			ok = msgs.Next()
 			require.True(t, ok)
 			require.Equal(t, "message-2", msgs.Message.Name)
+			require.Equal(t, 2, msgs.Message.Args.Count())
 			args = msgs.Message.Args.Map()
 			require.Equal(t, map[string]interface{}{
 				"key2-1": "value21",


### PR DESCRIPTION
I'm transforming each argument in a message to another map. I'd like to be able to allocate exactly the right map size ahead of time. This can also be done inside `Map()`.