### PR TITLE
Remove lib go-buffer-pool

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: Test
+      run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/criteo/haproxy-spoe-go
 go 1.15
 
 require (
-	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
-github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/spoe_test.go
+++ b/spoe_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	pool "github.com/libp2p/go-buffer-pool"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -144,6 +143,5 @@ func BenchmarkSPOE(b *testing.B) {
 		if err != nil {
 			b.Error(err)
 		}
-		pool.Put(res.originalData)
 	}
 }


### PR DESCRIPTION
We have a crash with the following stacktrace

************************
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x486366]

goroutine 222 [running]:
sync.(*WaitGroup).state(...)
        /usr/local/go/src/sync/waitgroup.go:33
sync.(*WaitGroup).Add(0x0, 0xffffffffffffffff)
        /usr/local/go/src/sync/waitgroup.go:54 +0x26
sync.(*WaitGroup).Done(...)
        /usr/local/go/src/sync/waitgroup.go:99
github.com/criteo/haproxy-spoe-go.(*conn).run.func3(0xc0005d63f0,
0xc0003d60c0)
        /home/c.paillet/git/haproxy-spoe-go/conn.go:119 +0x194
github.com/criteo/haproxy-spoe-go.(*conn).run(0xc0004b4050,
0xc0003d60c0, 0xefd0a0, 0xc000550590)
        /home/c.paillet/git/haproxy-spoe-go/conn.go:166 +0xeea
github.com/criteo/haproxy-spoe-go.(*Agent).Serve.func1(0xf17d20,
0xc00038c060, 0xc0003d60c0)
        /home/c.paillet/git/haproxy-spoe-go/spoe.go:100 +0xcc
created by github.com/criteo/haproxy-spoe-go.(*Agent).Serve
        /home/c.paillet/git/haproxy-spoe-go/spoe.go:93 +0x167
**************************

The problem seems in the lib go-buffer-pool.
ReadFull in frame.go:187 modify others variable (include acksKey), and create a crash
when we try to modify a.acksWG[acksKey] ( conn.go:104 )