### PR TITLE
Remove conn.go Waitgroup

### DIFF
--- a/disconnect.go
+++ b/disconnect.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (c *conn) disconnectFrame(e spoeError) (frame, error) {
-	f := frame{
+func (c *conn) disconnectFrame(e spoeError) (Frame, error) {
+	f := Frame{
 		frameID:  0,
 		streamID: 0,
 		ftype:    frameTypeAgentDiscon,
@@ -34,7 +34,7 @@ func (c *conn) disconnectFrame(e spoeError) (frame, error) {
 	return f, nil
 }
 
-func (c *conn) handleDisconnect(f frame) error {
+func (c *conn) handleDisconnect(f Frame) error {
 	data, _, err := decodeKVs(f.data, -1)
 	log.Debugf("spoe: Disconnect from %s: %+v", c.Conn.RemoteAddr(), data)
 	if err != nil {

--- a/frame.go
+++ b/frame.go
@@ -38,7 +38,7 @@ const (
 	frameFlagAbrt = 2
 )
 
-type frame struct {
+type Frame struct {
 	ftype        frameType
 	flags        frameFlag
 	streamID     int
@@ -61,7 +61,7 @@ func newCodec(conn net.Conn, cfg Config) *codec {
 	}
 }
 
-func (c *codec) decodeFrame(frame *frame) (bool, error) {
+func (c *codec) decodeFrame(frame *Frame) (bool, error) {
 	buffer := make([]byte, maxFrameSize)
 	frame.originalData = buffer
 
@@ -142,7 +142,7 @@ func (c *codec) decodeFrame(frame *frame) (bool, error) {
 	return true, nil
 }
 
-func (c *codec) encodeFrame(f frame) error {
+func (c *codec) encodeFrame(f Frame) error {
 
 	err := c.conn.SetWriteDeadline(time.Now().Add(c.cfg.WriteTimeout))
 	if err != nil {

--- a/frame_test.go
+++ b/frame_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestFrameEncoding(t *testing.T) {
-	f := frame{
+	f := Frame{
 		ftype:    frameTypeAgentACK,
 		flags:    frameFlagFin,
 		streamID: 42,
 		frameID:  53,
-		data:     []byte("this is the frame data"),
+		data:     []byte("this is the Frame data"),
 	}
 
 	server, client := net.Pipe()
@@ -26,7 +26,7 @@ func TestFrameEncoding(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	decoded := frame{}
+	decoded := Frame{}
 	ok, err := rcod.decodeFrame(&decoded)
 	require.Nil(t, err)
 	require.True(t, ok)

--- a/frames_test.go
+++ b/frames_test.go
@@ -4,9 +4,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func notifyFrame(t require.TestingT) frame {
+func notifyFrame(t require.TestingT) Frame {
 	b := make([]byte, maxFrameSize)
-	f := frame{
+	f := Frame{
 		ftype:    frameTypeHaproxyNotify,
 		streamID: 1,
 		frameID:  2,
@@ -42,8 +42,8 @@ func notifyFrame(t require.TestingT) frame {
 	return f
 }
 
-func helloFrame(t require.TestingT) frame {
-	f := frame{
+func helloFrame(t require.TestingT) Frame {
+	f := Frame{
 		ftype:    frameTypeHaproxyHello,
 		flags:    frameFlagFin,
 		streamID: 1,

--- a/hello.go
+++ b/hello.go
@@ -21,7 +21,7 @@ const (
 	capabilityPipelining = "pipelining"
 )
 
-func (c *conn) handleHello(frame frame) (frame, map[string]bool, bool, error) {
+func (c *conn) handleHello(frame Frame) (Frame, map[string]bool, bool, error) {
 	data, _, err := decodeKVs(frame.data, -1)
 	if err != nil {
 		return frame, nil, false, errors.Wrap(err, "hello")

--- a/notify.go
+++ b/notify.go
@@ -96,7 +96,7 @@ func (i *MessageIterator) Next() bool {
 	return true
 }
 
-func (c *conn) handleNotify(f frame, acks chan frame) error {
+func (c *conn) handleNotify(f Frame, acks chan Frame) error {
 	messages := &MessageIterator{
 		b: f.data,
 		Message: Message{

--- a/notify_test.go
+++ b/notify_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNotify(t *testing.T) {
 	data := make([]byte, maxFrameSize)
-	f := frame{
+	f := Frame{
 		data:         data,
 		originalData: data,
 	}
@@ -86,7 +86,7 @@ func TestNotify(t *testing.T) {
 		},
 	}
 
-	out := make(chan frame, 1)
+	out := make(chan Frame, 1)
 	err = conn.handleNotify(f, out)
 	require.Nil(t, err)
 	require.True(t, handlerCalled)

--- a/spoe.go
+++ b/spoe.go
@@ -29,7 +29,7 @@ var defaultConfig = Config{
 	IdleTimeout:  30 * time.Second,
 }
 
-type FrameKey struct {
+type EngKey struct {
 	FrameSize int
 	Engine    string
 	Conn      net.Conn
@@ -41,21 +41,24 @@ type Agent struct {
 
 	maxFrameSize int
 
-	framesLock sync.Mutex
-	frames     map[FrameKey]chan Frame
-	framesWG   map[FrameKey]*sync.WaitGroup
+	engLock sync.Mutex
+	engines  map[EngKey]*Engine
 }
 
 func New(h Handler) *Agent {
 	return NewWithConfig(h, defaultConfig)
 }
 
+type Engine struct {
+	frames    chan Frame
+	count     int32
+}
+
 func NewWithConfig(h Handler, cfg Config) *Agent {
 	return &Agent{
-		Handler:  h,
-		cfg:      cfg,
-		frames:   make(map[FrameKey]chan Frame),
-		framesWG: make(map[FrameKey]*sync.WaitGroup),
+		Handler: h,
+		cfg:     cfg,
+		engines: make(map[EngKey]*Engine),
 	}
 }
 

--- a/spoe_test.go
+++ b/spoe_test.go
@@ -33,7 +33,7 @@ func TestSPOE(t *testing.T) {
 	helloReq := helloFrame(t)
 	require.NoError(t, cod.encodeFrame(helloReq))
 
-	helloRes := frame{}
+	helloRes := Frame{}
 	ok, err := cod.decodeFrame(&helloRes)
 	require.True(t, ok)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestSPOE(t *testing.T) {
 	notifyReq := notifyFrame(t)
 	require.NoError(t, cod.encodeFrame(notifyReq))
 
-	notifyRes := frame{}
+	notifyRes := Frame{}
 	ok, err = cod.decodeFrame(&notifyRes)
 	require.True(t, ok)
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestSPOEUnix(t *testing.T) {
 	helloReq := helloFrame(t)
 	require.NoError(t, cod.encodeFrame(helloReq))
 
-	helloRes := frame{}
+	helloRes := Frame{}
 	ok, err := cod.decodeFrame(&helloRes)
 	require.True(t, ok)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestSPOEUnix(t *testing.T) {
 	notifyReq := notifyFrame(t)
 	require.NoError(t, cod.encodeFrame(notifyReq))
 
-	notifyRes := frame{}
+	notifyRes := Frame{}
 	ok, err = cod.decodeFrame(&notifyRes)
 	require.True(t, ok)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func BenchmarkSPOE(b *testing.B) {
 	require.NoError(b, cod.encodeFrame(helloReq))
 
 	notifyReq := notifyFrame(b)
-	res := frame{}
+	res := Frame{}
 
 	ok, err := cod.decodeFrame(&res)
 	require.True(b, ok)


### PR DESCRIPTION
- Remove Waitgroup and replace it by a count for
each engine. We can count the number of current frame
for each engine, and destry the engine when there is no more frame.
- Rename somes vars ( acks to frame / capitalize first later of types )