### PR TITLE
Expose StreamID from Frame

### DIFF
--- a/disconnect.go
+++ b/disconnect.go
@@ -2,6 +2,7 @@ package spoe
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -9,7 +10,7 @@ import (
 func (c *conn) disconnectFrame(e spoeError) (Frame, error) {
 	f := Frame{
 		frameID:  0,
-		streamID: 0,
+		StreamID: 0,
 		ftype:    frameTypeAgentDiscon,
 		flags:    frameFlagFin,
 		data:     make([]byte, c.frameSize),

--- a/frame.go
+++ b/frame.go
@@ -43,7 +43,7 @@ const (
 type Frame struct {
 	ftype        frameType
 	flags        frameFlag
-	streamID     int
+	StreamID     int
 	frameID      int
 	data         []byte
 	originalData []byte
@@ -142,7 +142,7 @@ func (c *codec) decodeFrame(frame *Frame) (bool, error) {
 	}
 	off += n
 
-	frame.streamID = streamID
+	frame.StreamID = streamID
 	frame.frameID = frameID
 	frame.data = frame.data[off:]
 	return true, nil
@@ -169,7 +169,7 @@ func (c *codec) encodeFrame(f Frame) error {
 	binary.BigEndian.PutUint32(header[off:], uint32(f.flags))
 	off += 4
 
-	n, err := encodeVarint(header[off:], f.streamID)
+	n, err := encodeVarint(header[off:], f.StreamID)
 	if err != nil {
 		return errors.Wrap(err, "write frame")
 	}

--- a/frame_test.go
+++ b/frame_test.go
@@ -12,7 +12,7 @@ func TestFrameEncoding(t *testing.T) {
 	f := Frame{
 		ftype:    frameTypeAgentACK,
 		flags:    frameFlagFin,
-		streamID: 42,
+		StreamID: 42,
 		frameID:  53,
 		data:     []byte("this is the Frame data"),
 	}

--- a/frames_test.go
+++ b/frames_test.go
@@ -8,7 +8,7 @@ func notifyFrame(t require.TestingT) Frame {
 	b := make([]byte, maxFrameSize)
 	f := Frame{
 		ftype:    frameTypeHaproxyNotify,
-		streamID: 1,
+		StreamID: 1,
 		frameID:  2,
 		data:     b,
 	}
@@ -46,7 +46,7 @@ func helloFrame(t require.TestingT) Frame {
 	f := Frame{
 		ftype:    frameTypeHaproxyHello,
 		flags:    frameFlagFin,
-		streamID: 1,
+		StreamID: 1,
 		frameID:  1,
 		data:     make([]byte, maxFrameSize),
 	}

--- a/spoe_test.go
+++ b/spoe_test.go
@@ -39,7 +39,7 @@ func TestSPOE(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, err)
 
-	require.Equal(t, helloReq.streamID, helloRes.streamID)
+	require.Equal(t, helloReq.StreamID, helloRes.StreamID)
 
 	// notify
 	notifyReq := notifyFrame(t)
@@ -50,7 +50,7 @@ func TestSPOE(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, err)
 
-	require.Equal(t, notifyReq.streamID, notifyRes.streamID)
+	require.Equal(t, notifyReq.StreamID, notifyRes.StreamID)
 }
 
 func TestSPOEUnix(t *testing.T) {
@@ -87,7 +87,7 @@ func TestSPOEUnix(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, err)
 
-	require.Equal(t, helloReq.streamID, helloRes.streamID)
+	require.Equal(t, helloReq.StreamID, helloRes.StreamID)
 
 	// notify
 	notifyReq := notifyFrame(t)
@@ -98,7 +98,7 @@ func TestSPOEUnix(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, err)
 
-	require.Equal(t, notifyReq.streamID, notifyRes.streamID)
+	require.Equal(t, notifyReq.StreamID, notifyRes.StreamID)
 }
 
 func BenchmarkSPOE(b *testing.B) {


### PR DESCRIPTION
I need the stream ID for my spoa logging therefore I offer this poor mans patch.
See https://github.com/criteo/haproxy-spoe-go/issues/28 for more information